### PR TITLE
Add task properties support

### DIFF
--- a/Documentation/etcd.md
+++ b/Documentation/etcd.md
@@ -17,14 +17,17 @@ that implementing Metafora with etcd in your own work system is quick and easy.
     │           └── <command>  JSON value
     └── tasks
         └── <task_id>
-            └── owner          Ephemeral
-                               JSON value
+            ├── props          JSON value
+            └── owner          Ephemeral, JSON value
 ```
 
 ##### Tasks
 
-Metafora clients submit tasks by making an empty directory in
-`/<namespace>/tasks/` without a TTL.
+Metafora clients submit tasks by making either: 
+
+* an empty directory in `/<namespace>/tasks/`
+* a new directory containing a single file `/<namespace>/tasks/props`
+  * `props` may have a JSON encoded value of string keys and values
 
 Metafora nodes claim tasks by watching the `tasks` directory and -- if
 `Balancer.CanClaim` returns `true` -- tries to create the

--- a/Documentation/introduction.md
+++ b/Documentation/introduction.md
@@ -1,24 +1,42 @@
-## Introduction 
+## Introduction
 
-Metafora is a framework for creating highly available and distributed services written in Go.  Metafora is embeded meaning your code controls how and when metafora is started.  It uses etcd to coordinate across the nodes in your cluster.  Metafora is a leaderless task distribution system where the nodes coordinate with each other to ensure that work is evenly distributed over the cluster. 
+Metafora is a framework for creating highly available and distributed services
+written in Go.  Metafora is embeded meaning your code controls how and when
+metafora is started.  It uses etcd to coordinate across the nodes in your
+cluster.  Metafora is a leaderless task distribution system where the nodes
+coordinate with each other to ensure that work is evenly distributed over the
+cluster.
 
-Metafora is an embedded work stealing framework built on top of etcd.  
+Metafora is an embedded work stealing framework built on top of etcd.
 
-![logical1](/Documentation/images/metafora_logical_integration_diagram.png) 
+![logical1](/Documentation/images/metafora_logical_integration_diagram.png)
 
 ## Overview
 
-Metafora gives you the ablity to build an elastic distributed application.  It makes it easy to build applications that scale in or out, and that can recover from node failures.  The following diagrams are examples of how this works. 
+Metafora gives you the ablity to build an elastic distributed application.  It
+makes it easy to build applications that scale in or out, and that can recover
+from node failures.  The following diagrams are examples of how this works.
 
 #### Node failure or scaling in
 
-When a node fails (or you scale in your nodes), metafora will will release the tasks from the missing node back into the task pool.  Other metafora nodes will detect the unclaimed tasks and attempt to claim them.  It's important to note that metafora simple manages the reassigment of tasks, its upto your code (possiable in your metafora handler) to cleanup any bad state caused by a tasks crashing during processing.
+When a node fails (or you scale in your nodes), metafora will will release the
+tasks from the missing node back into the task pool.  Other metafora nodes will
+detect the unclaimed tasks and attempt to claim them.  It's important to note
+that metafora simply manages the reassigment of tasks, its up to your code
+(possibly in your metafora handler) to cleanup any bad state caused by a tasks
+crashing during processing.
 
 ![logical1](/Documentation/images/metafora_nodefailure.png)
- 
+
 
 #### Node recovery or scaling out
 
-When a new node joins the cluster it begins picking up new tasks immediately.  Initially the other nodes may have more tasks because they've been in the cluster longer.  To address this, occasionally the members compare task load and rebalance the tasks between them.  
+When a new node joins the cluster it begins picking up new tasks immediately.
+Initially the other nodes may have more tasks because they've been in the
+cluster longer.  To address this, occasionally the members compare task load
+and rebalance the tasks between them.
+
+Balancing logic is controlled by the Balancer implementation you pass to the
+Consumer.
 
 ![logical1](/Documentation/images/metafora_node_recovery.png)

--- a/balancer_res_test.go
+++ b/balancer_res_test.go
@@ -2,6 +2,8 @@ package metafora
 
 import "testing"
 
+var _ Balancer = &ResourceBalancer{}
+
 type fakeReporter struct {
 	used  uint64
 	total uint64
@@ -48,9 +50,7 @@ func TestResourceBalancer(t *testing.T) {
 		t.Errorf("Expected 1 released task but found: %v", release)
 	}
 
-	//FIXME When #93 is fixed this test should break as CanClaim should actually
-	//      return false
-	if !bal.CanClaim("claimmepls") {
-		t.Errorf("Until #93 is fixed, CanClaim should always return true")
+	if _, ok := bal.CanClaim(nil); ok {
+		t.Errorf("Balancer should not have claimed task but did!")
 	}
 }

--- a/balancer_sleep.go
+++ b/balancer_sleep.go
@@ -32,8 +32,8 @@ func (b *SleepBalancer) Init(ctx BalancerContext) { b.ctx = ctx }
 func (*SleepBalancer) Balance() []string { return nil }
 
 // CanClaim sleeps 30ms per claimed task.
-func (b *SleepBalancer) CanClaim(string) bool {
+func (b *SleepBalancer) CanClaim(Task) (time.Time, bool) {
 	num := len(b.ctx.Tasks())
 	time.Sleep(time.Duration(num) * sleepBalLen)
-	return true
+	return NoDelay, true
 }

--- a/client.go
+++ b/client.go
@@ -1,15 +1,10 @@
 package metafora
 
 type Client interface {
-	// SubmitTask submits a task to the system, the task id must be unique.
-	SubmitTask(taskId string) error
-
-	// Delete a task
-	DeleteTask(taskId string) error
+	// SubmitTask submits a task to the broker for Metafora consumers to claim.
+	// The ID must be unique. Properties may be nil.
+	SubmitTask(id string, props map[string]string) error
 
 	// SubmitCommand submits a command to a particular node.
 	SubmitCommand(node string, command Command) error
-
-	// Nodes retrieves the current set of registered nodes.
-	Nodes() ([]string, error)
 }

--- a/coordinator.go
+++ b/coordinator.go
@@ -20,7 +20,7 @@ type Coordinator interface {
 
 	// Watch the broker for tasks. Watch blocks until Close is called or it
 	// encounters an error. Tasks are sent to consumer via the tasks chan.
-	Watch(tasks chan<- string) (err error)
+	Watch(tasks chan<- Task) (err error)
 
 	// Claim is called by the Consumer when a Balancer has determined that a task
 	// ID can be claimed. Claim returns false if another consumer has already

--- a/embedded/client.go
+++ b/embedded/client.go
@@ -2,36 +2,21 @@ package embedded
 
 import "github.com/lytics/metafora"
 
-func NewEmbeddedClient(taskchan chan string, cmdchan chan *NodeCommand, nodechan chan []string) metafora.Client {
-	return &EmbeddedClient{taskchan, cmdchan, nodechan}
+func NewEmbeddedClient(taskchan chan<- metafora.Task, cmdchan chan<- *NodeCommand) metafora.Client {
+	return &EmbeddedClient{taskchan, cmdchan}
 }
 
 type EmbeddedClient struct {
-	taskchan chan<- string
+	taskchan chan<- metafora.Task
 	cmdchan  chan<- *NodeCommand
-	nodechan <-chan []string
 }
 
-func (ec *EmbeddedClient) SubmitTask(taskid string) error {
-	ec.taskchan <- taskid
-	return nil
-}
-
-func (ec *EmbeddedClient) DeleteTask(taskid string) error {
-	nodes, _ := ec.Nodes()
-	// Simply submit stop for all nodes
-	for _, nid := range nodes {
-		ec.SubmitCommand(nid, metafora.CommandStopTask(taskid))
-	}
+func (ec *EmbeddedClient) SubmitTask(id string, props map[string]string) error {
+	ec.taskchan <- NewTask(id, props)
 	return nil
 }
 
 func (ec *EmbeddedClient) SubmitCommand(nodeid string, command metafora.Command) error {
 	ec.cmdchan <- &NodeCommand{command, nodeid}
 	return nil
-}
-
-func (ec *EmbeddedClient) Nodes() ([]string, error) {
-	nodes := <-ec.nodechan
-	return nodes, nil
 }

--- a/embedded/embedded_test.go
+++ b/embedded/embedded_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEmbedded(t *testing.T) {
-
+	t.Parallel()
 	tc := newTestCounter()
 	adds := make(chan string, 4)
 
@@ -25,7 +25,7 @@ func TestEmbedded(t *testing.T) {
 	go runner.Run()
 
 	for _, taskid := range []string{"one", "two", "three", "four"} {
-		err := client.SubmitTask(taskid)
+		err := client.SubmitTask(taskid, nil)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -51,6 +51,7 @@ func TestEmbedded(t *testing.T) {
 }
 
 func TestEmbeddedShutdown(t *testing.T) {
+	t.Parallel()
 	const n = 4
 	runs := make(chan int, n)
 	stops := make(chan int, n)
@@ -75,7 +76,7 @@ func TestEmbeddedShutdown(t *testing.T) {
 
 	// submit tasks
 	for _, taskid := range tasks {
-		err := client.SubmitTask(taskid)
+		err := client.SubmitTask(taskid, nil)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}

--- a/embedded/util.go
+++ b/embedded/util.go
@@ -9,12 +9,11 @@ type NodeCommand struct {
 
 // Returns a connected client/coordinator pair for embedded/testing use
 func NewEmbeddedPair(nodeid string) (metafora.Coordinator, metafora.Client) {
-	taskchan := make(chan string)
+	taskchan := make(chan metafora.Task)
 	cmdchan := make(chan *NodeCommand)
-	nodechan := make(chan []string, 1)
 
-	coord := NewEmbeddedCoordinator(nodeid, taskchan, cmdchan, nodechan)
-	client := NewEmbeddedClient(taskchan, cmdchan, nodechan)
+	coord := NewEmbeddedCoordinator(nodeid, taskchan, cmdchan)
+	client := NewEmbeddedClient(taskchan, cmdchan)
 
 	return coord, client
 }

--- a/examples/koalemosctl/main.go
+++ b/examples/koalemosctl/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	// Finally create the task for metafora
 	mc := m_etcd.NewClient(*namespace, ec)
-	if err := mc.SubmitTask(taskID); err != nil {
+	if err := mc.SubmitTask(taskID, nil); err != nil {
 		fmt.Println("Error submitting task:", taskID)
 		os.Exit(5)
 	}

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -12,15 +12,15 @@ import (
 // introspection endpoints.
 type Consumer interface {
 	Frozen() bool
-	Tasks() []metafora.Task
+	Tasks() []metafora.RunningTask
 }
 
 // InfoResponse is the JSON response marshalled by the MakeInfoHandler.
 type InfoResponse struct {
-	Frozen  bool            `json:"frozen"`
-	Node    string          `json:"node"`
-	Started time.Time       `json:"started"`
-	Tasks   []metafora.Task `json:"tasks"`
+	Frozen  bool                   `json:"frozen"`
+	Node    string                 `json:"node"`
+	Started time.Time              `json:"started"`
+	Tasks   []metafora.RunningTask `json:"tasks"`
 }
 
 // MakeInfoHandler returns an HTTP handler which can be added to an exposed

--- a/httputil/httputil_test.go
+++ b/httputil/httputil_test.go
@@ -15,7 +15,7 @@ type tc struct {
 }
 
 func (*tc) Init(metafora.CoordinatorContext) error { return nil }
-func (c *tc) Watch(chan<- string) error {
+func (c *tc) Watch(chan<- metafora.Task) error {
 	<-c.stop
 	return nil
 }

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestIgnore(t *testing.T) {
 	t.Parallel()
-	out := make(chan string)
+	out := make(chan Task)
 	stop := make(chan struct{})
 	defer close(stop)
 
@@ -16,7 +16,7 @@ func TestIgnore(t *testing.T) {
 
 	// Ignore task for 200ms. Yes this is racy. Might need to bump deadline.
 	deadline1 := time.Now().Add(200 * time.Millisecond)
-	im.add("1", deadline1)
+	im.add(&TestTask{id: "1"}, deadline1)
 
 	// Ensure it's ignored
 	if !im.ignored("1") {
@@ -26,11 +26,11 @@ func TestIgnore(t *testing.T) {
 	// Ignore task for 10ms to make sure tasks are returned in order (they aren't
 	// *guaranteed* to be in order since adds and evictions are concurrent)
 	deadline2 := time.Now().Add(10 * time.Millisecond)
-	im.add("2", deadline2)
+	im.add(&TestTask{id: "2"}, deadline2)
 
 	// Wait for the first eviction
 	eviction := <-out
-	if eviction != "2" {
+	if eviction.ID() != "2" {
 		t.Fatal("Expected 2 to be evicted before 1")
 	}
 	now := time.Now()
@@ -39,7 +39,7 @@ func TestIgnore(t *testing.T) {
 	}
 
 	eviction = <-out
-	if eviction != "1" {
+	if eviction.ID() != "1" {
 		t.Fatal("Expected 1 to be evicted second, found ", eviction)
 	}
 	now = time.Now()

--- a/m_etcd/client_test.go
+++ b/m_etcd/client_test.go
@@ -1,87 +1,65 @@
 package m_etcd
 
-// NOTES
-//
-// These tests are in reality integration tests which require that
-// etcd is running on the test system and its peers are found
-// in the ENV variable ETCDCTL_PEERS. The tests do not clean
-// out data and require a fresh set of etcd instances for
-// each run. You can consider this a known bug which
-// will be fixed in a future release.
-//
-// See: https://github.com/lytics/metafora/issues/31
-
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/lytics/metafora"
 )
 
-const (
-	Namespace = `test`
-	NodesDir  = `/test/nodes`
-	Node1     = `node1`
-	Node1Path = NodesDir + `/` + Node1
-)
-
-// TestNodes tests that client.Nodes() returns the metafora nodes
-// registered in etcd.
-func TestNodes(t *testing.T) {
-	eclient := newEtcdClient(t)
-	const recursive = true
-	eclient.Delete(Node1Path, recursive)
-
-	mclient := NewClient(Namespace, eclient)
-
-	if _, err := eclient.CreateDir(Node1Path, 0); err != nil {
-		t.Fatalf("AddChild %v returned error: %v", NodesDir, err)
-	}
-
-	if nodes, err := mclient.Nodes(); err != nil {
-		t.Fatalf("Nodes returned error: %v", err)
-	} else {
-		for i, n := range nodes {
-			t.Logf("%v -> %v", i, n)
-		}
-	}
-}
-
 // TestSubmitTask tests that client.SubmitTask(...) adds a task to
 // the proper path in etcd, and that the same task id cannot be
 // submitted more than once.
 func TestSubmitTask(t *testing.T) {
-	eclient := newEtcdClient(t)
+	_, eclient := setupEtcd(t)
 
-	mclient := NewClient(Namespace, eclient)
+	mclient := NewClient(namespace, eclient)
 
-	if err := mclient.DeleteTask("testid1"); err != nil {
-		t.Logf("DeleteTask returned an error, which maybe ok.  Error:%v", err)
-	}
-
-	if err := mclient.SubmitTask("testid1"); err != nil {
+	if err := mclient.SubmitTask("testid1", nil); err != nil {
 		t.Fatalf("Submit task failed on initial submission, error: %v", err)
 	}
 
-	if err := mclient.SubmitTask("testid1"); err == nil {
+	if err := mclient.SubmitTask("testid1", nil); err == nil {
 		t.Fatalf("Submit task did not fail, but should of, when using existing tast id")
+	}
+
+	if err := mclient.SubmitTask("testid2", map[string]string{"k": "v"}); err != nil {
+		t.Fatalf("Submit task (2) failed on initial submission, error: %v", err)
+	}
+	resp, err := eclient.Get(namespace+"/tasks/testid2/props", false, false)
+	if err != nil {
+		t.Fatalf("Error retrieving task 2's properties: %v", err)
+	}
+
+	var props map[string]string
+	err = json.Unmarshal([]byte(resp.Node.Value), &props)
+	if err != nil {
+		t.Fatalf("Error unmarshalling properties: %v", err)
+	}
+	if len(props["_submitted"]) == 0 {
+		t.Errorf("Missing builtin _submitted key: %#v", props)
+	}
+	if props["k"] != "v" {
+		t.Errorf("Didn't find expected property k=v: k=%q", props["k"])
 	}
 }
 
 // TestSubmitCommand tests that client.SubmitCommand(...) adds a command
 // to the proper node path in etcd, and that it can be read back.
 func TestSubmitCommand(t *testing.T) {
-	eclient := newEtcdClient(t)
+	_, eclient := setupEtcd(t)
 
-	mclient := NewClient(Namespace, eclient)
+	mclient := NewClient(namespace, eclient)
 
-	if err := mclient.SubmitCommand(Node1, metafora.CommandFreeze()); err != nil {
+	if err := mclient.SubmitCommand(nodeID, metafora.CommandFreeze()); err != nil {
 		t.Fatalf("Unable to submit command.   error:%v", err)
 	}
 
-	if res, err := eclient.Get(NodesDir, false, false); err != nil {
-		t.Fatalf("Get on path %v returned error: %v", NodesDir, err)
+	ndir := namespace + "/nodes"
+	if res, err := eclient.Get(ndir, false, false); err != nil {
+		t.Fatalf("Get on path %v returned error: %v", ndir, err)
 	} else if res.Node == nil || res.Node.Nodes == nil {
-		t.Fatalf("Get on path %v returned nil for child nodes", NodesDir)
+		t.Fatalf("Get on path %v returned nil for child nodes", ndir)
 	} else {
 		for i, n := range res.Node.Nodes {
 			t.Logf("%v -> %v", i, n)

--- a/m_etcd/const.go
+++ b/m_etcd/const.go
@@ -5,7 +5,6 @@ const (
 	NodesPath    = "nodes"
 	CommandsPath = "commands"
 	MetadataKey  = "_metafora" // _{KEYs} are hidden files, so this will not trigger our watches
-	OwnerMarker  = "owner"
 
 	ForeverTTL = 0 //Ref: https://github.com/coreos/go-etcd/blob/e10c58ee110f54c2f385ac99764e8a7ca4cb13df/etcd/requests.go#L356
 

--- a/m_etcd/parse_test.go
+++ b/m_etcd/parse_test.go
@@ -1,6 +1,7 @@
 package m_etcd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/go-etcd/etcd"
@@ -13,50 +14,95 @@ func (ctx) Lost(string)                                   {}
 func (ctx) Log(metafora.LogLevel, string, ...interface{}) {}
 
 type taskTest struct {
-	Resp *etcd.Response
-	Task string
-	Ok   bool
+	Resp  *etcd.Response
+	Resp2 *etcd.Response // response to second GET
+	Task  metafora.Task
+	Ok    bool
+}
+
+func (t taskTest) Get(key string, _ bool, _ bool) (*etcd.Response, error) {
+	if t.Resp2 == nil {
+		return nil, fmt.Errorf("no response")
+	}
+	return t.Resp2, nil
+}
+
+func (t taskTest) propsEqual(other map[string]string) bool {
+	me := t.Task.Props()
+	for k, v := range other {
+		if me[k] != v {
+			return false
+		}
+	}
+	for k, v := range me {
+		if other[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func TestParseTask(t *testing.T) {
-	c := EtcdCoordinator{taskPath: "/namespace/tasks", cordCtx: &ctx{}}
+	path := "/namespace/tasks"
 
 	tests := []taskTest{
 		// bad
 		{Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/namespace/tasks/1", Dir: true}}},
-		{Resp: &etcd.Response{Action: actionCreated, Node: &etcd.Node{Key: "/namespace/tasks/1/a", Dir: true}}},
-		{Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/namespace/tasks/1", Dir: false}}},
+		{Resp: &etcd.Response{Action: actionCreated, Node: &etcd.Node{Key: "/namespace/tasks/2/a", Dir: true}}},
+		{Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/namespace/tasks/3", Dir: false}}},
+		{
+			Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/namespace/tasks/3.1/owner"}},
+			Resp2: &etcd.Response{Node: &etcd.Node{Nodes: etcd.Nodes{
+				&etcd.Node{Key: "/namespace/tasks/3.1/props", Value: `invalid json`},
+			}}},
+			Ok: false,
+		},
 
 		// good
 		{
-			Resp: &etcd.Response{Action: actionCreated, Node: &etcd.Node{Key: "/namespace/tasks/1", Dir: true}},
-			Task: "1",
+			Resp: &etcd.Response{Action: actionCreated, Node: &etcd.Node{Key: "/namespace/tasks/4", Dir: true}},
+			Task: &task{id: "4"},
 			Ok:   true,
 		},
 		{
-			Resp: &etcd.Response{Action: actionSet, Node: &etcd.Node{Key: "/namespace/tasks/1", Dir: true}},
-			Task: "1",
+			Resp: &etcd.Response{Action: actionSet, Node: &etcd.Node{Key: "/namespace/tasks/5", Dir: true}},
+			Task: &task{id: "5"},
 			Ok:   true,
 		},
 		{
-			Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/namespace/tasks/1/owner"}},
-			Task: "1",
+			Resp: &etcd.Response{Action: actionCAD, Node: &etcd.Node{Key: "/namespace/tasks/6/owner"}},
+			Resp2: &etcd.Response{Node: &etcd.Node{Nodes: etcd.Nodes{
+				&etcd.Node{Key: "/namespace/tasks/6/ignoreme", Value: "-"},
+				&etcd.Node{Key: "/namespace/tasks/6/props", Value: `{"k":"v"}`},
+			}}},
+			Task: &task{id: "6", props: map[string]string{"k": "v"}},
 			Ok:   true,
 		},
 		{
-			Resp: &etcd.Response{Action: actionDelete, Node: &etcd.Node{Key: "/namespace/tasks/1/owner"}},
-			Task: "1",
+			Resp: &etcd.Response{Action: actionDelete, Node: &etcd.Node{Key: "/namespace/tasks/7/owner"}},
+			Resp2: &etcd.Response{Node: &etcd.Node{Nodes: etcd.Nodes{
+				&etcd.Node{Key: "/namespace/tasks/6/props", Value: `{"x":"1", "y": "2"}`},
+			}}},
+			Task: &task{id: "7", props: map[string]string{"x": "1", "y": "2"}},
 			Ok:   true,
 		},
 	}
 
 	for _, test := range tests {
-		task, ok := c.parseTask(test.Resp)
-		if task != test.Task {
-			t.Errorf("Test %s:%v failed: %s != %s", test.Resp.Action, *test.Resp.Node, task, test.Task)
-		}
-		if ok != test.Ok {
-			t.Errorf("Test %s:%v failed: %v != %v", test.Resp.Action, *test.Resp.Node, ok, test.Ok)
+		task, ok := parseTask(test, test.Resp, path)
+		switch {
+		case test.Task == nil && task != nil:
+			t.Errorf("Test %s:%v failed: expected nil but received: %v", test.Resp.Action, test.Resp.Node.Key, task)
+		case test.Task != nil && task == nil:
+			t.Errorf("Test %s:%v failed: received nil but expected: %v", test.Resp.Action, test.Resp.Node.Key, test.Task)
+		case (task != nil && test.Task != nil) && task.ID() != test.Task.ID():
+			t.Errorf("Test %s:%v failed: %s != %s", test.Resp.Action, test.Resp.Node.Key, task.ID(), test.Task.ID())
+		case (task != nil && test.Task != nil) && !test.propsEqual(task.Props()):
+			t.Errorf("Test %s:%v failed: %#v != %#v", test.Resp.Action, test.Resp.Node.Key, task.Props(), test.Task.Props())
+		case ok != test.Ok:
+			t.Errorf("Test %s:%v failed: %v != %v", test.Resp.Action, test.Resp.Node.Key, ok, test.Ok)
+		default:
+			t.Logf("Test %s:%v OK", test.Resp.Action, test.Resp.Node.Key)
 		}
 	}
 }

--- a/m_etcd/task.go
+++ b/m_etcd/task.go
@@ -1,0 +1,122 @@
+package m_etcd
+
+import (
+	"encoding/json"
+	"path"
+	"strings"
+
+	"github.com/coreos/go-etcd/etcd"
+	"github.com/lytics/metafora"
+)
+
+const (
+	// etcd/Response.Action values
+	actionCreated = "create"
+	actionSet     = "set"
+	actionExpire  = "expire"
+	actionDelete  = "delete"
+	actionCAD     = "compareAndDelete"
+
+	// claimMarker is the name of the key marking a task as claimed
+	claimMarker = "owner"
+
+	// propsKey is the name of the key containing properties
+	propsKey = "props"
+)
+
+var (
+	// etcd actions signifying a claim key was released
+	releaseActions = map[string]bool{
+		actionExpire: true,
+		actionDelete: true,
+		actionCAD:    true,
+	}
+
+	// etcd actions signifying a new key
+	newActions = map[string]bool{
+		actionCreated: true,
+		actionSet:     true,
+	}
+)
+
+type task struct {
+	id    string
+	props map[string]string
+}
+
+func (t *task) ID() string               { return t.id }
+func (t *task) Props() map[string]string { return t.props }
+
+// etcdGetter defines the specific subset of etcd.Client required by parseTask
+// to make testing easier.
+type etcdGetter interface {
+	Get(key string, _ bool, _ bool) (*etcd.Response, error)
+}
+
+// parseTask creates a new task from an etcd response or returns false.
+func parseTask(c etcdGetter, resp *etcd.Response, basePath string) (*task, bool) {
+	// Sanity check / test path invariant
+	if !strings.HasPrefix(resp.Node.Key, basePath) {
+		metafora.Errorf("Received task from outside task path: %s", resp.Node.Key)
+		return nil, false
+	}
+
+	key := strings.Trim(resp.Node.Key, "/") // strip leading and trailing /s
+	parts := strings.Split(key, "/")
+
+	// Pickup new tasks from directory events
+	if newActions[resp.Action] && len(parts) == 3 && resp.Node.Dir {
+		return findProps(&task{id: parts[2]}, resp.Node.Nodes)
+	}
+
+	// Pickup new tasks from props file
+	if newActions[resp.Action] && len(parts) == 4 && !resp.Node.Dir && parts[3] == propsKey {
+		// Unmarshal properties
+		newtask := task{id: parts[2]}
+		err := json.Unmarshal([]byte(resp.Node.Value), &newtask.props)
+		if err != nil {
+			metafora.Errorf("Error unmarshalling props for task=%q: %v", newtask.id, err)
+			return nil, false
+		}
+		return &newtask, true
+	}
+
+	// If a claim key is removed, get the properties and return the task if it's
+	// not reclaimed already
+	if releaseActions[resp.Action] && len(parts) == 4 && parts[3] == claimMarker {
+		newtask := task{id: parts[2]}
+
+		const sorted = false
+		const recursive = true
+		resp, err := c.Get("/"+path.Join(parts[0], parts[1], parts[2]), sorted, recursive)
+		if err != nil {
+			metafora.Errorf("Failed retrieving properties for released task=%q: %v", newtask.id, err)
+			return nil, false
+		}
+		return findProps(&newtask, resp.Node.Nodes)
+	}
+
+	// Ignore any other key events (_metafora keys, task deletion, etc.)
+	return nil, false
+}
+
+// findProps iterates over a list of etcd nodes and loads any property files it
+// finds. If it discovers a claim marker it short circuits with a failure as
+// the task is inclaimable.
+func findProps(task *task, nodes etcd.Nodes) (*task, bool) {
+	for _, node := range nodes {
+		if strings.HasSuffix(node.Key, claimMarker) {
+			metafora.Debugf("Ignoring task=%q as it's already reclaimed.", task.id)
+			return nil, false
+		}
+		if strings.HasSuffix(node.Key, propsKey) {
+			err := json.Unmarshal([]byte(node.Value), &task.props)
+			if err != nil {
+				metafora.Errorf("Error unmarshalling props for task=%q: %v", task.id, err)
+				return nil, false
+			}
+		}
+	}
+	metafora.Debugf("Received task=%q", task.id)
+	return task, true
+}

--- a/m_etcd/taskmgr.go
+++ b/m_etcd/taskmgr.go
@@ -67,7 +67,7 @@ func (m *taskManager) taskPath(taskID string) string {
 }
 
 func (m *taskManager) ownerKey(taskID string) string {
-	return path.Join(m.taskPath(taskID), OwnerMarker)
+	return path.Join(m.taskPath(taskID), claimMarker)
 }
 
 func (m *taskManager) ownerNode(taskID string) (key, value string) {

--- a/metafora_test.go
+++ b/metafora_test.go
@@ -115,9 +115,9 @@ type testBalancer struct {
 }
 
 func (b *testBalancer) Init(c BalancerContext) { b.c = c }
-func (b *testBalancer) CanClaim(taskID string) (time.Time, bool) {
-	b.t.Logf("CanClaim(%s) -> %t", taskID, taskID == "ok-task")
-	return time.Now().Add(100 * time.Hour), taskID == "ok-task"
+func (b *testBalancer) CanClaim(task Task) (time.Time, bool) {
+	b.t.Logf("CanClaim(%s) -> %t", task.ID(), task.ID() == "ok-task")
+	return time.Now().Add(100 * time.Hour), task.ID() == "ok-task"
 }
 func (b *testBalancer) Balance() []string {
 	if b.secondRun {

--- a/slowtask_test.go
+++ b/slowtask_test.go
@@ -14,7 +14,7 @@ func (b *releaseAllBalancer) Init(c BalancerContext) {
 	b.ctx = c
 	b.balances = make(chan int)
 }
-func (b *releaseAllBalancer) CanClaim(string) (time.Time, bool) { return NoDelay, true }
+func (b *releaseAllBalancer) CanClaim(Task) (time.Time, bool) { return NoDelay, true }
 func (b *releaseAllBalancer) Balance() []string {
 	b.balances <- 1
 	ids := []string{}

--- a/task.go
+++ b/task.go
@@ -6,20 +6,39 @@ import (
 	"time"
 )
 
+// Task is the core interface returned by Coordinators.
 type Task interface {
+	// ID returns the unique task identifier.
 	ID() string
+
+	// Props returns the metadata property map for the task. It should not be
+	// mutated.
+	//
+	// Properties starting with an underscore are reserved for use by Metafora.
+	Props() map[string]string
+}
+
+// RunningTask exposes extra metadata about a Task once it's running in
+// metafora.
+type RunningTask interface {
+	Task
+
+	// Started is the time the task started running locally.
 	Started() time.Time
+
+	// Stopped is the first time the Consumer called Stop() on the task's
+	// handler (or zero if Stop hasn't been called).
 	Stopped() time.Time
+
 	json.Marshaler
 }
 
-// task is the per-task state Metafora tracks internally.
-type task struct {
+// runningtask is the per-task state Metafora tracks internally.
+type runningtask struct {
+	Task
+
 	// handler on which Run and Stop are called
 	h Handler
-
-	// id of task to satisfy Task interface
-	id string
 
 	// stopL serializes calls to task.h.Stop() to make handler implementations
 	// easier/safer as well as guard stopped
@@ -30,11 +49,11 @@ type task struct {
 	stopped time.Time
 }
 
-func newTask(id string, h Handler) *task {
-	return &task{id: id, h: h, started: time.Now()}
+func newTask(task Task, h Handler) *runningtask {
+	return &runningtask{Task: task, h: h, started: time.Now()}
 }
 
-func (t *task) stop() {
+func (t *runningtask) stop() {
 	t.stopL.Lock()
 	defer t.stopL.Unlock()
 	if t.stopped.IsZero() {
@@ -43,20 +62,20 @@ func (t *task) stop() {
 	t.h.Stop()
 }
 
-func (t *task) ID() string         { return t.id }
-func (t *task) Started() time.Time { return t.started }
-func (t *task) Stopped() time.Time {
+func (t *runningtask) Started() time.Time { return t.started }
+func (t *runningtask) Stopped() time.Time {
 	t.stopL.Lock()
 	defer t.stopL.Unlock()
 	return t.stopped
 }
 
-func (t *task) MarshalJSON() ([]byte, error) {
+func (t *runningtask) MarshalJSON() ([]byte, error) {
 	js := struct {
-		ID      string     `json:"id"`
-		Started time.Time  `json:"started"`
-		Stopped *time.Time `json:"stopped,omitempty"`
-	}{ID: t.id, Started: t.started}
+		ID      string            `json:"id"`
+		Props   map[string]string `json:"props"`
+		Started time.Time         `json:"started"`
+		Stopped *time.Time        `json:"stopped,omitempty"`
+	}{ID: t.ID(), Props: t.Props(), Started: t.started}
 
 	// Only set stopped if it's non-zero
 	if s := t.Stopped(); !s.IsZero() {

--- a/util_test.go
+++ b/util_test.go
@@ -6,6 +6,19 @@ import "errors"
 //is that existing metafora tests would have to be moved to the metafora_test
 //package which means no manipulating unexported globals like balance jitter.
 
+var (
+	_ Coordinator = (*TestCoord)(nil)
+	_ Task        = (*TestTask)(nil)
+)
+
+type TestTask struct {
+	id    string
+	props map[string]string
+}
+
+func (t *TestTask) ID() string               { return t.id }
+func (t *TestTask) Props() map[string]string { return t.props }
+
 type TestCoord struct {
 	Tasks    chan string // will be returned in order, "" indicates return an error
 	Commands chan Command
@@ -32,7 +45,7 @@ func (c *TestCoord) Done(task string)            { c.Dones <- task }
 
 // Watch sends tasks from the Tasks channel unless an empty string is sent.
 // Then an error is returned.
-func (c *TestCoord) Watch(out chan<- string) error {
+func (c *TestCoord) Watch(out chan<- Task) error {
 	task := ""
 	for {
 		select {
@@ -45,7 +58,7 @@ func (c *TestCoord) Watch(out chan<- string) error {
 			return nil
 		}
 		select {
-		case out <- task:
+		case out <- &TestTask{id: task}:
 			Debugf("TestCoord sent: %s", task)
 		case <-c.closed:
 			return nil


### PR DESCRIPTION
**Coordinator and Balancer breaking API changes**

Fixes #100

Tasks now can have extra metadata (properties) and internally are
repesented as an interface instead of a simple string ID.

The intention is to offer a minimal amount of metadata for balancers and
handlers to use when deciding what to do with a task. It is _not_ meant
to be used as the canonical store for task configuration as there's no
support for changing the metadata and notifying handlers of changes.

We also don't want the coordinator to consider the broker a general
purpose database. Using it as a distributed lock is already difficult
enough without piling more complexity into it.

Also fixes a tiny obscure bug in fair balancer where it might try to
release the same task more than once per `Balance()` call.

**Client API changes**
- `Client.Nodes` was removed as it's not really useful enough to force
  clients to implement it.
- `Client.DeleteTask` was removed because it was dangerous and should
  _never_ be used.
- `Client.SubmitTask` now accepts a properties map.
